### PR TITLE
各チャンクのアラインメント仕様を遵守するようにした

### DIFF
--- a/vrm/gltf.py
+++ b/vrm/gltf.py
@@ -130,6 +130,7 @@ def indexing(gltf):
     offset = 0
     for buffer_view in buffer_views:
         data = buffer_view.pop('data')
+        data = data.ljust((len(data) + 3) / 4 * 4, '\0') # 4バイトアラインメント
         length = len(data)
         buffer_view['buffer'] = 0  # 1バッファにまとめるのでインデックスは0
         buffer_view['byteOffset'] = offset

--- a/vrm/vrm.py
+++ b/vrm/vrm.py
@@ -35,6 +35,7 @@ class VRM(object):
         with open(path, 'wb') as fo:
             gltf, chunks = indexing(self.gltf)  # 参照をインデックス番号に変換
             gltf_encoded = json.dumps(gltf).encode('utf-8')
+            gltf_encoded = gltf_encoded.ljust((len(gltf_encoded) + 3) / 4 * 4) # 4バイトアラインメント
             glb_length = 20 + len(gltf_encoded) + sum(map(len, chunks))
 
             # glTF header


### PR DESCRIPTION
仕様は下記の通りです

- JSONチャンクは4バイトアラインメントで空白文字で埋める。
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#structured-json-content

- バイナリチャンクは4バイトアラインメントでNULL文字で埋める。
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#binary-buffer