### PR TITLE
設定ファイル機能を追加

### DIFF
--- a/example/example-conf-VRoidStudio-Sendagaya_Shino.toml
+++ b/example/example-conf-VRoidStudio-Sendagaya_Shino.toml
@@ -1,0 +1,79 @@
+# このファイルは --conf で使用できる設定ファイルの例です。
+# VRoid Studio 0.8.3 時点でデフォルトで使用可能な Sendagaya Shino の最適化設定例です。
+
+# --conf 機能は独自のテクスチャー、素体、服などを使用した VRM に対して使用したい場合や、
+# VRoid Studio の 更新があり VReducer の内蔵定義が追いついていない場合に便利かもしれません。
+
+# なお、 TOML 形式定義データの構造をツリー構造で見たり、JSONやYAMLと比較してみたい場合は
+# https://toolkit.site/format.html
+# を使うと幸せになれるかもしれません。
+
+# 制服上下、リボン、靴
+[material.resize_info._Tops_._Tops_]
+pos  = [    0,    0 ]
+size = [ 2048, 2536 ]
+[material.resize_info._Tops_._Bottoms_]
+pos  = [    0, 1536 ]
+size = [  512,  512 ]
+[material.resize_info._Tops_._Accessory_]
+pos  = [  512, 1536 ]
+size = [  512,  512 ]
+[material.resize_info._Tops_._Shoes_]
+pos  = [ 1024, 1536 ]
+size = [  512,  512 ]
+
+# 体、顔、口
+[material.resize_info._Face_._Face_]
+pos  = [    0,    0 ]
+size = [  512,  512 ]
+[material.resize_info._Face_._FaceMouth_]
+pos  = [  512,    0 ]
+size = [  512,  512 ]
+[material.resize_info._Face_._Body_]
+pos  = [    0,  512 ]
+size = [ 2048, 1536 ]
+
+# アイライン、まつ毛
+# Note: VRoid Studio の他のデータでは _EyeExtra_ 相当の
+# マテリアルが _FaceEyeSP に入っている場合もあるようです。
+[material.resize_info._FaceEyeline_._EyeExtra_]
+pos  = [    0,  512 ]
+size = [ 1024,  512 ]
+[material.resize_info._FaceEyeline_._FaceEyeline_]
+pos  = [    0,  512 ]
+size = [ 1024,  512 ]
+[material.resize_info._FaceEyeline_._FaceEyelash_]
+pos  = [    0, 1024 ]
+size = [ 1024,  512 ]
+
+# 瞳孔、ハイライト、白目
+[material.resize_info._EyeHighlight_._EyeIris_]
+pos  = [    0,    0 ]
+size = [ 1024,  512 ]
+[material.resize_info._EyeHighlight_._EyeHighlight_]
+pos  = [    0,  512 ]
+size = [ 1024,  512 ]
+[material.resize_info._EyeHighlight_._EyeWhite_]
+pos  = [    0, 1024 ]
+size = [ 1024,  512 ]
+
+# ↓のように resize_info_near をテーブルを使うと、
+# 1. _HairBack_ (=TOMLのテーブル名)に "部分一致" するマテリアル(*1)を探し、
+# 2. (*1)_と色の近い _Hair_ (=near_key)に "部分一致" するマテリアル(*2)を探し、
+# 3. (*1) を pos, size 、(*2) を near_pos, near_size で_(*2) へ統合
+# します。
+
+# 髪の毛、頭の下毛
+[material.resize_info_near._HairBack_]
+pos  = [  512,    0 ]
+size = [ 1024, 1024 ]
+near_key = "_Hair_"
+near_pos  = [    0,    0 ]
+near_size = [  512, 1024 ]
+
+# material.modify を定義すると特定のマテリアルのパラメーターを変更できます
+# ↓は本体内蔵機能でも対応しているレンダータイプの変更を行う場合の例です
+[material.modify._Face_.keywordMap]
+_ALPHATEST_ON = true
+[material.modify._Face_.tagMap]
+RenderType = "TransparentCutout"

--- a/vreducer.py
+++ b/vreducer.py
@@ -28,7 +28,12 @@ def main(argv):
                         help='Change texture size less equal than this size. (-t 512,512)')
     parser.add_argument('-f', '--force', action='store_true', help='Overwrite file if already exists same file.')
     parser.add_argument('-V', '--version', action='version', version=app_name())
+    parser.add_argument('-c', '--conf', help='Set a configuration file path.')
     opt = parser.parse_args(argv)
+
+    if opt.conf:
+        import toml
+        opt.conf = toml.load(open(opt.conf))
 
     path = opt.path
     print(path)
@@ -39,7 +44,7 @@ def main(argv):
     print_stat(vrm.gltf)
 
     print('-' * 30)
-    vrm.gltf = reduce_vroid(vrm.gltf, opt.replace_shade_color, parse_texture_size(opt.texture_size), opt.emissive_color)
+    vrm.gltf = reduce_vroid(vrm.gltf, opt.replace_shade_color, parse_texture_size(opt.texture_size), opt.emissive_color, m if opt.conf and (m:=opt.conf.get('material')) else None )
 
     print('-' * 30)
     print_stat(vrm.gltf)


### PR DESCRIPTION
## このパッチで追加される機能

- `-c`, `--conf` コマンドライン引数が追加されます。この引数はオプショナルです。
    - `python vreducer.py my.vrm --conf my-conf.toml` のように使用します。
    - 設定ファイルを明示的に使用すると、 VReducer 内蔵定義では対応できない VRM データにも対応しやすくなります。
- 設定ファイルの例が `example/example-conf-VRoidStudio-Sendagaya_Shino.toml` に追加されます。
    - 設定ファイルはとりあえず TOML 形式に対応で、 material.{ resize_info, resize_info_near, material_modify } の3つの設定にこのパッチの段階で対応します。
    - `material.resize_info`: この直下のテーブル群の名前に部分一致するマテリアルへ、その下段に連なるテーブル群の名前に部分一致するマテリアルを統合する設定です。
    - `material.resize_info_near`: ある名前に部分一致するマテリアルに近い色で別のある名前に部分一致するマテリアルを統合する設定です。
    - `material.modify`: この直下のテーブル群の名前に対応するマテリアルの値を直接書き換える設定です。

Note: このパッチで追加される `--conf` を使用する場合に限り [`toml`](https://github.com/uiri/toml) パッケージが必要です。 `--conf` を使用しない場合は不要でこれまで通りに動作します。 ( `pip install toml` )

## このパッチの動悸

- VRoid Studio でも独自のテクスチャー、素体、服などを使用したい場合への対応性を向上したい。
- VRoid Studio のアップデートへやバリエーションの増加に対し VReducer 本体の内蔵定義の更新を待たずに対応できる可能性を持たせたい。
- VRoid Studio 以外のアプリで作成した VRM にもユーザーが定義さえ作れっば対応可能となる未来を見たい。

-----

参考: https://github.com/usagi/VReducer/issues/1